### PR TITLE
Fixing canvas resizing in the openfl html5 target.

### DIFF
--- a/flash/Lib.hx
+++ b/flash/Lib.hx
@@ -278,8 +278,15 @@ class Lib {
 		
 		// This ensures that a canvas hitTest hits the root movieclip
 		
-		Lib.current.graphics.beginFill (__getStage ().backgroundColor);
-		Lib.current.graphics.drawRect (0, 0, width, height);
+		function resizeBackground(?event:Event) {
+			Lib.current.graphics.clear();
+			Lib.current.graphics.beginFill(__getStage().backgroundColor);
+			Lib.current.graphics.drawRect(0, 0, Lib.current.stage.stageWidth, Lib.current.stage.stageHeight);
+		}
+
+		__getStage().addEventListener(Event.RESIZE, resizeBackground);
+		resizeBackground();
+		
 		__setSurfaceId (Lib.current.graphics.__surface, "Root MovieClip");
 		__getStage ().__updateNextWake ();
 


### PR DESCRIPTION
Changing the root movie clip canvas to change size when the resize event is dispatched.

As long as OpenFL draws the background to the root movie clip, we'll want the dimensions of that background to match the dimensions of the stage. Otherwise, the stage won't dispatch mouse events outside its initial dimensions when the stage is expanded.

The downside to this is that it clears Lib.current whenever the app resizes. An alternative to this approach is to draw these graphics somewhere else, or to use a different method to catch mouse events and draw the stage.